### PR TITLE
Avoid allocations when parsing integers

### DIFF
--- a/resp/bench_test.go
+++ b/resp/bench_test.go
@@ -1,0 +1,120 @@
+package resp
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func BenchmarkIntUnmarshalRESP(b *testing.B) {
+	tests := []struct {
+		Input string
+	}{
+		{"-1"},
+		{"-123"},
+		{"1"},
+		{"123"},
+		{"+1"},
+		{"+123"},
+	}
+
+	for _, test := range tests {
+		input := ":" + test.Input + "\r\n"
+
+		b.Run(fmt.Sprint(test.Input), func(b *testing.B) {
+			var sr strings.Reader
+			br := bufio.NewReader(&sr)
+
+			for i := 0; i < b.N; i++ {
+				sr.Reset(input)
+				br.Reset(&sr)
+
+				var i Int
+				if err := i.UnmarshalRESP(br); err != nil {
+					b.Fatalf("failed to unmarshal %q: %s", test.Input, err)
+				}
+			}
+		})
+	}
+}
+
+var bfloat float64
+
+func BenchmarkReadFloat(b *testing.B) {
+	tests := []struct {
+		In string
+	}{
+		{"1"},
+		{"1.23"},
+		{"-1"},
+		{"-1.23"},
+		{"+1"},
+		{"+1.23"},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
+			var r strings.Reader
+
+			for i := 0; i < b.N; i++ {
+				r.Reset(test.In)
+				bfloat, _ = readFloat(&r, 64)
+			}
+		})
+	}
+}
+
+var bint int64
+
+func BenchmarkReadInt(b *testing.B) {
+	tests := []struct {
+		In string
+	}{
+		{"1"},
+		{"123"},
+		{"-1"},
+		{"-123"},
+		{"+1"},
+		{"+123"},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
+			var r strings.Reader
+
+			for i := 0; i < b.N; i++ {
+				r.Reset(test.In)
+				bint, _ = readInt(&r)
+			}
+		})
+	}
+}
+
+var buint uint64
+
+func BenchmarkReadUint(b *testing.B) {
+	tests := []struct {
+		In string
+	}{
+		{"1"},
+		{"123"},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
+			var r strings.Reader
+
+			for i := 0; i < b.N; i++ {
+				r.Reset(test.In)
+				buint, _ = readUint(&r)
+			}
+		})
+	}
+}

--- a/resp/bench_test.go
+++ b/resp/bench_test.go
@@ -9,7 +9,7 @@ import (
 
 func BenchmarkIntUnmarshalRESP(b *testing.B) {
 	tests := []struct {
-		Input string
+		In string
 	}{
 		{"-1"},
 		{"-123"},
@@ -20,9 +20,9 @@ func BenchmarkIntUnmarshalRESP(b *testing.B) {
 	}
 
 	for _, test := range tests {
-		input := ":" + test.Input + "\r\n"
+		input := ":" + test.In + "\r\n"
 
-		b.Run(fmt.Sprint(test.Input), func(b *testing.B) {
+		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
 			var sr strings.Reader
 			br := bufio.NewReader(&sr)
 
@@ -32,7 +32,7 @@ func BenchmarkIntUnmarshalRESP(b *testing.B) {
 
 				var i Int
 				if err := i.UnmarshalRESP(br); err != nil {
-					b.Fatalf("failed to unmarshal %q: %s", test.Input, err)
+					b.Fatalf("failed to unmarshal %q: %s", input, err)
 				}
 			}
 		})
@@ -54,13 +54,13 @@ func BenchmarkReadFloat(b *testing.B) {
 	}
 
 	for _, test := range tests {
-		test := test
+		input := test.In
 
 		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
 			var r strings.Reader
 
 			for i := 0; i < b.N; i++ {
-				r.Reset(test.In)
+				r.Reset(input)
 				bfloat, _ = readFloat(&r, 64)
 			}
 		})
@@ -82,13 +82,13 @@ func BenchmarkReadInt(b *testing.B) {
 	}
 
 	for _, test := range tests {
-		test := test
+		input := test.In
 
 		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
 			var r strings.Reader
 
 			for i := 0; i < b.N; i++ {
-				r.Reset(test.In)
+				r.Reset(input)
 				bint, _ = readInt(&r)
 			}
 		})
@@ -106,13 +106,13 @@ func BenchmarkReadUint(b *testing.B) {
 	}
 
 	for _, test := range tests {
-		test := test
+		input := test.In
 
 		b.Run(fmt.Sprint(test.In), func(b *testing.B) {
 			var r strings.Reader
 
 			for i := 0; i < b.N; i++ {
-				r.Reset(test.In)
+				r.Reset(input)
 				buint, _ = readUint(&r)
 			}
 		})


### PR DESCRIPTION
When parsing integers, either as part of the protocol itself or when unmarshaling, the code currently needs to convert the parsed `[]byte` into a `string` since there are no functions for parsing integers from `[]byte`s in the [strconv](https://golang.org/pkg/strconv) package.

This PR replaces the use of strconv.ParseInt and strconv.ParseUint with custom functions that take a `[]byte` instead of a `string` and only support base-10.

```
name                     old time/op    new time/op    delta
IntUnmarshalRESP/-1-8      83.6ns ± 0%    66.6ns ± 2%   -20.37%  (p=0.000 n=9+9)
IntUnmarshalRESP/-12-8     87.6ns ± 1%    66.9ns ± 2%   -23.57%  (p=0.000 n=10+10)
IntUnmarshalRESP/-123-8    90.3ns ± 1%    67.9ns ± 1%   -24.83%  (p=0.000 n=10+8)
IntUnmarshalRESP/1-8       72.0ns ± 1%    65.3ns ± 0%    -9.32%  (p=0.000 n=10+8)
IntUnmarshalRESP/12-8      85.9ns ± 1%    67.0ns ± 1%   -22.00%  (p=0.000 n=10+9)
IntUnmarshalRESP/123-8     89.7ns ± 0%    67.1ns ± 1%   -25.22%  (p=0.000 n=10+8)
IntUnmarshalRESP/+1-8      84.3ns ± 0%    66.9ns ± 1%   -20.67%  (p=0.000 n=10+9)
IntUnmarshalRESP/+12-8     88.1ns ± 0%    66.5ns ± 2%   -24.59%  (p=0.000 n=10+10)
IntUnmarshalRESP/+123-8    90.3ns ± 0%    67.8ns ± 2%   -24.93%  (p=0.000 n=9+10)
ReadInt/1-8                 201ns ± 5%     190ns ± 5%    -5.48%  (p=0.000 n=10+10)
ReadInt/123-8               219ns ± 4%     192ns ± 2%   -12.55%  (p=0.000 n=10+9)
ReadInt/-1-8                212ns ± 5%     189ns ± 3%   -10.94%  (p=0.000 n=10+10)
ReadInt/-123-8              216ns ± 1%     191ns ± 4%   -11.48%  (p=0.000 n=9+10)
ReadInt/+1-8                213ns ± 4%     191ns ± 4%   -10.39%  (p=0.000 n=10+10)
ReadInt/+123-8              217ns ± 3%     192ns ± 3%   -11.36%  (p=0.000 n=10+10)
ReadUint/1-8                192ns ± 2%     185ns ± 3%    -3.84%  (p=0.000 n=10+10)
ReadUint/123-8              210ns ± 2%     188ns ± 4%   -10.75%  (p=0.000 n=10+10)

name                     old alloc/op   new alloc/op   delta
IntUnmarshalRESP/-1-8       2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/-12-8      3.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/-123-8     4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/1-8        0.00B          0.00B           ~     (all equal)
IntUnmarshalRESP/12-8       2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/123-8      3.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+1-8       2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+12-8      3.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+123-8     4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
ReadInt/1-8                  112B ± 0%      112B ± 0%      ~     (all equal)
ReadInt/123-8                115B ± 0%      112B ± 0%    -2.61%  (p=0.000 n=10+10)
ReadInt/-1-8                 114B ± 0%      112B ± 0%    -1.75%  (p=0.000 n=10+10)
ReadInt/-123-8               116B ± 0%      112B ± 0%    -3.45%  (p=0.000 n=10+10)
ReadInt/+1-8                 114B ± 0%      112B ± 0%    -1.75%  (p=0.000 n=10+10)
ReadInt/+123-8               116B ± 0%      112B ± 0%    -3.45%  (p=0.000 n=10+10)
ReadUint/1-8                 112B ± 0%      112B ± 0%      ~     (all equal)
ReadUint/123-8               115B ± 0%      112B ± 0%    -2.61%  (p=0.000 n=10+10)

name                     old allocs/op  new allocs/op  delta
IntUnmarshalRESP/-1-8        1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/-12-8       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/-123-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/1-8         0.00           0.00           ~     (all equal)
IntUnmarshalRESP/12-8        1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/123-8       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+1-8        1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+12-8       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IntUnmarshalRESP/+123-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ReadInt/1-8                  1.00 ± 0%      1.00 ± 0%      ~     (all equal)
ReadInt/123-8                2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ReadInt/-1-8                 2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ReadInt/-123-8               2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ReadInt/+1-8                 2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ReadInt/+123-8               2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ReadUint/1-8                 1.00 ± 0%      1.00 ± 0%      ~     (all equal)
ReadUint/123-8               2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
```