### PR TITLE
avoid allocations when unmarshaling

### DIFF
--- a/resp/bench_test.go
+++ b/resp/bench_test.go
@@ -2,7 +2,9 @@ package resp
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -114,6 +116,25 @@ func BenchmarkReadUint(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				r.Reset(input)
 				buint, _ = readUint(&r)
+			}
+		})
+	}
+}
+
+func BenchmarkReadAllAppend(b *testing.B) {
+	respBytes := []byte("$5\r\nhello\r\n")
+
+	for _, bcap := range []int{0, len(respBytes), len(respBytes) + bytes.MinRead} {
+		b.Run("Capacity"+strconv.Itoa(bcap), func(b *testing.B) {
+			var br bytes.Reader
+			buf := make([]byte, 0, bcap)
+
+			for i := 0; i < b.N; i++ {
+				br.Reset(respBytes)
+
+				if _, err := readAllAppend(&br, buf); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/resp/resp.go
+++ b/resp/resp.go
@@ -78,6 +78,22 @@ func putBytes(b *[]byte) {
 	bytePool.Put(b)
 }
 
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, bytes.MinRead)
+		return bytes.NewBuffer(b)
+	},
+}
+
+func getBuffer() *bytes.Buffer {
+	return bufferPool.Get().(*bytes.Buffer)
+}
+
+func putBuffer(b *bytes.Buffer) {
+	b.Reset()
+	bufferPool.Put(b)
+}
+
 // parseInt is a specialized version of strconv.ParseInt that parses a base-10 encoded signed integer.
 func parseInt(b []byte) (int64, error) {
 	if len(b) == 0 {
@@ -179,12 +195,17 @@ func bufferedIntDelim(br *bufio.Reader) (int64, error) {
 }
 
 func readAllAppend(r io.Reader, b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(b)
+	buf := getBuffer()
 	// a side effect of this is that the given b will be re-allocated if
 	// it's less than bytes.MinRead. Since this b could be all the way from the
 	// user we can't guarantee it within the library
 	_, err := buf.ReadFrom(r)
-	return buf.Bytes(), err
+	b = append(b, buf.Bytes()...)
+	putBuffer(buf)
+	if b == nil {
+		b = []byte{}
+	}
+	return b, err
 }
 
 func multiWrite(w io.Writer, bb ...[]byte) error {

--- a/resp/resp.go
+++ b/resp/resp.go
@@ -196,10 +196,12 @@ func bufferedIntDelim(br *bufio.Reader) (int64, error) {
 
 func readAllAppend(r io.Reader, b []byte) ([]byte, error) {
 	buf := getBuffer()
-	// a side effect of this is that the given b will be re-allocated if
-	// it's less than bytes.MinRead. Since this b could be all the way from the
-	// user we can't guarantee it within the library
 	_, err := buf.ReadFrom(r)
+	// reading into buf and copying is in most cases faster than creating
+	// a new buffer for b since it can avoid allocating the buffer (when
+	// there is a buffer in the pool). It also avoids reallocating b when
+	// b is smaller than bytes.MinRead bytes (see the documentation on
+	// bytes.MinRead) and the data fits into b.
 	b = append(b, buf.Bytes()...)
 	putBuffer(buf)
 	if b == nil {


### PR DESCRIPTION
Currently `readAllAppend` allocates a `*bytes.Buffer` on each call. Also for slices with less than bytes.MinRead bytes (512) the buffer will allocate a new `[]byte` even if the old slice could fit all the data.

In most cases the capacity of the `[]byte` is rather small (64 bytes in most cases, which is the capacity used by `getBytes` for new slices), which means that most calls will allocate at least 3 times.

Avoid this by reading into pooled buffers and appending the data to the given `[]byte`.

Also add a benchmark that calls `readAllAppend` with different capacities to show the different allocation cases.

Benchmark results:

```
name                         old time/op    new time/op    delta
ReadAllAppend/Capacity0-8       965ns ± 3%      99ns ± 3%   -89.76%  (p=0.000 n=15+15)
ReadAllAppend/Capacity11-8      439ns ± 5%      66ns ± 2%   -85.02%  (p=0.000 n=15+13)
ReadAllAppend/Capacity523-8     121ns ± 6%      67ns ± 3%   -44.45%  (p=0.000 n=15+15)

name                         old alloc/op   new alloc/op   delta
ReadAllAppend/Capacity0-8      2.16kB ± 0%    0.02kB ± 0%   -99.26%  (p=0.000 n=15+15)
ReadAllAppend/Capacity11-8       688B ± 0%        0B       -100.00%  (p=0.000 n=15+15)
ReadAllAppend/Capacity523-8      112B ± 0%        0B       -100.00%  (p=0.000 n=15+15)

name                         old allocs/op  new allocs/op  delta
ReadAllAppend/Capacity0-8        3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=15+15)
ReadAllAppend/Capacity11-8       2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
ReadAllAppend/Capacity523-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
```