### PR TITLE
Use JoinHostPort for IPs from sentinel

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -2,10 +2,10 @@ package radix
 
 import (
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"time"
-	"net"
 )
 
 type sentinelOpts struct {

--- a/sentinel.go
+++ b/sentinel.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net"
 )
 
 type sentinelOpts struct {
@@ -222,7 +223,7 @@ func (sc *Sentinel) ensureMaster(conn Conn) error {
 	} else if m["ip"] == "" || m["port"] == "" {
 		return errors.New("malformed SENTINEL MASTER response")
 	}
-	newAddr := m["ip"] + ":" + m["port"]
+	newAddr := net.JoinHostPort(m["ip"], m["port"])
 	if newAddr == lastAddr {
 		return nil
 	}
@@ -257,7 +258,7 @@ func (sc *Sentinel) ensureSentinelAddrs(conn Conn) error {
 
 	addrs := map[string]bool{conn.NetConn().RemoteAddr().String(): true}
 	for _, m := range mm {
-		addrs[m["ip"]+":"+m["port"]] = true
+		addrs[net.JoinHostPort(m["ip"], m["port"])] = true
 	}
 
 	sc.l.Lock()

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -111,7 +111,7 @@ func (s *sentinelStub) switchMaster(newAddr string) {
 func TestSentinel(t *T) {
 	stub := sentinelStub{
 		instAddr:  "127.0.0.1:6379",
-		sentAddrs: []string{"127.0.0.1:26379", "127.0.0.2:26379"},
+		sentAddrs: []string{"127.0.0.1:26379", "127.0.0.2:26379", "[0:0:0:0:0:ffff:7f00:3]:26379"},
 		stubChs:   map[chan<- PubSubMessage]bool{},
 	}
 
@@ -152,13 +152,13 @@ func TestSentinel(t *T) {
 		wg.Wait()
 	}
 
-	assertState("127.0.0.1:6379", "127.0.0.1:26379", "127.0.0.2:26379")
+	assertState("127.0.0.1:6379", "127.0.0.1:26379", "127.0.0.2:26379", "[0:0:0:0:0:ffff:7f00:3]:26379")
 	assertPoolWorks()
 
 	stub.switchMaster("127.0.0.2:6379")
 	go assertPoolWorks()
 	assert.Equal(t, "switch-master completed", <-scc.testEventCh)
-	assertState("127.0.0.2:6379", "127.0.0.1:26379", "127.0.0.2:26379")
+	assertState("127.0.0.2:6379", "127.0.0.1:26379", "127.0.0.2:26379", "[0:0:0:0:0:ffff:7f00:3]:26379")
 
 	assertPoolWorks()
 }


### PR DESCRIPTION
IPv6 addresses need special handling when joining with a port. Although probably a rare case\*, we can just use net.JoinHostPort which accounts for this.

\* In fact I just started a sentinel server just to check if it even supports IPv6 and yes, it does.