### PR TITLE
Fix AUTH example

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -86,7 +86,7 @@
 //			return nil, err
 //		}
 //
-//		if err := conn.Do(radix.Cmd("AUTH", "mySuperSecretPassword")); err != nil {
+//		if err := conn.Do(radix.Cmd(nil, "AUTH", "mySuperSecretPassword")); err != nil {
 //			conn.Close()
 //			return nil, err
 //		}


### PR DESCRIPTION
This was passing "AUTH" as the first parameter where the receiver should be, so this was failing with an error that "mySuperSecretPassword" is an invalid command.