### PR TITLE
Avoid allocating in Keys methods

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -280,3 +280,23 @@ func ExampleMaybeNil() {
 	}
 
 }
+
+var benchCmdActionKeys []string // global variable used to store the action keys in benchmarks
+
+func BenchmarkCmdActionKeys(b *B) {
+	for i := 0; i < b.N; i++ {
+		benchCmdActionKeys = Cmd(nil, "GET", "a").Keys()
+	}
+}
+
+func BenchmarkFlatCmdActionKeys(b *B) {
+	for i := 0; i < b.N; i++ {
+		benchCmdActionKeys = FlatCmd(nil, "GET", "a").Keys()
+	}
+}
+
+func BenchmarkWithConnKeys(b *B) {
+	for i := 0; i < b.N; i++ {
+		benchCmdActionKeys = WithConn("a", func(Conn) error { return nil }).Keys()
+	}
+}


### PR DESCRIPTION
Improves performance of the Keys methods for Cmd, FlatCmd and WithConn,
by storing the key as a [1]string that can be sliced instead of storing
it as a normal string and creating a slice in the Keys methods. Since
the array is part of the structsn no additional allocation is required.

```
name                 old time/op    new time/op    delta
CmdActionKeys-8         161ns ± 4%     135ns ± 3%  -16.14%  (p=0.000 n=9+10)
FlatCmdActionKeys-8     110ns ± 3%      78ns ± 3%  -28.85%  (p=0.000 n=10+9)
WithConnKeys-8         82.0ns ± 2%    51.2ns ± 4%  -37.51%  (p=0.000 n=10+10)

name                 old alloc/op   new alloc/op   delta
CmdActionKeys-8         96.0B ± 0%     80.0B ± 0%  -16.67%  (p=0.000 n=10+10)
FlatCmdActionKeys-8     96.0B ± 0%     80.0B ± 0%  -16.67%  (p=0.000 n=10+10)
WithConnKeys-8          48.0B ± 0%     32.0B ± 0%  -33.33%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
CmdActionKeys-8          3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
FlatCmdActionKeys-8      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WithConnKeys-8           2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```