### PR TITLE
Preallocate space in new maps in resp.Any

### DIFF
--- a/resp/resp.go
+++ b/resp/resp.go
@@ -951,7 +951,7 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 		if size%2 != 0 {
 			return errors.New("cannot decode redis array with odd number of elements into map")
 		} else if v.IsNil() {
-			v.Set(reflect.MakeMap(v.Type()))
+			v.Set(reflect.MakeMapWithSize(v.Type(), size / 2))
 		}
 
 		for i := 0; i < size; i += 2 {


### PR DESCRIPTION
Possible since 1.9, avoids a few allocations in most cases