### PR TITLE
Avoid unnecessary allocations on each cluster action

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -136,6 +136,19 @@ func TestClusterDo(t *T) {
 	}
 }
 
+func BenchmarkClusterDo(b *B) {
+	c, _ := newTestCluster()
+
+	k, v := clusterSlotKeys[0], randStr()
+	require.Nil(b, c.Do(Cmd(nil, "SET", k, v)))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		require.Nil(b, c.Do(Cmd(nil, "GET", k)))
+	}
+}
+
 func TestClusterWithPrimaries(t *T) {
 	c, _ := newTestCluster()
 	var topo ClusterTopo


### PR DESCRIPTION
No change in performance in the tests, but less allocated bytes and allocations in total.

```
name         old time/op    new time/op    delta
ClusterDo-8    5.59µs ± 1%    5.60µs ± 3%     ~     (p=0.434 n=9+10)

name         old alloc/op   new alloc/op   delta
ClusterDo-8    4.85kB ± 0%    4.78kB ± 0%   -1.37%  (p=0.000 n=9+9)

name         old allocs/op  new allocs/op  delta
ClusterDo-8      20.0 ± 0%      17.0 ± 0%  -15.00%  (p=0.000 n=10+10)
```

Fixes #32 