### PR TITLE
Return unexpected io.EOF for bulk strings to the user

### DIFF
--- a/resp/resp.go
+++ b/resp/resp.go
@@ -785,7 +785,7 @@ func (a Any) UnmarshalRESP(br *bufio.Reader) error {
 		} else if l == -1 {
 			return a.unmarshalNil()
 		}
-		if err := a.unmarshalSingle(br, int(l)); err != nil && err != io.EOF {
+		if err := a.unmarshalSingle(br, int(l)); err != nil {
 			return err
 		}
 		_, err = br.Discard(2)


### PR DESCRIPTION
If we encounter an io.EOF before the bulk string ends we should report it to the user instead of assuming that the Discard call returns io.EOF too.