### PR TITLE
Use net.Buffers for multiWrite

### DIFF
--- a/resp/resp.go
+++ b/resp/resp.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"reflect"
 	"strconv"
 	"sync"
@@ -226,12 +227,9 @@ func readNDiscard(r io.Reader, n int) error {
 }
 
 func multiWrite(w io.Writer, bb ...[]byte) error {
-	for _, b := range bb {
-		if _, err := w.Write(b); err != nil {
-			return err
-		}
-	}
-	return nil
+	nb := net.Buffers(bb)
+	_, err := nb.WriteTo(w)
+	return err
 }
 
 func readInt(r io.Reader, n int) (int64, error) {


### PR DESCRIPTION
Simplifies multiWrite a bit and helps in cases when a user writes directly to a net.Conn, by avoiding some syscalls.