### PR TITLE
Add support for XGROUP and XINFO in Redis Cluster

### DIFF
--- a/action.go
+++ b/action.go
@@ -237,6 +237,13 @@ func (c *cmdAction) Keys() []string {
 	cmd := strings.ToUpper(c.cmd)
 	if cmd == "BITOP" && len(c.args) > 1 { // antirez why you do this
 		return c.args[1:]
+	} else if cmd == "XINFO" {
+		if len(c.args) < 2 {
+			return nil
+		}
+		return c.args[1:2]
+	} else if cmd == "XGROUP" && len(c.args) > 1 {
+		return c.args[1:2]
 	} else if cmd == "XREAD" || cmd == "XREADGROUP" { // antirez why you still do this
 		return findStreamsKeys(c.args)
 	} else if noKeyCmds[cmd] || len(c.args) == 0 {


### PR DESCRIPTION
With Redis 5.0 released (finally!) the remaining stream commands are also now finalized and we need to add support for XINFO and XGROUP. XINFO is again a bit special, since one case (XINFO HELP) does not take any key. 