### PR TITLE
Revert "Use net.Buffers for multiWrite"

### DIFF
--- a/resp/resp.go
+++ b/resp/resp.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"reflect"
 	"strconv"
 	"sync"
@@ -227,9 +226,12 @@ func readNDiscard(r io.Reader, n int) error {
 }
 
 func multiWrite(w io.Writer, bb ...[]byte) error {
-	nb := net.Buffers(bb)
-	_, err := nb.WriteTo(w)
-	return err
+	for _, b := range bb {
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func readInt(r io.Reader, n int) (int64, error) {


### PR DESCRIPTION
This reverts commit 9063563cd4f4e9800df2069d19af0fcdd412076a.

Using net.Buffers caused quite a few allocations in the common case, which lead to worse performance and more work for the GC.

Updates #42 